### PR TITLE
removing max line length

### DIFF
--- a/styles/fixable.js
+++ b/styles/fixable.js
@@ -58,16 +58,6 @@ module.exports = {
 			},
 		],
 
-		'max-len': [
-			'warn',
-			{
-				code: 80,
-				ignoreComments: true,
-				ignoreRegExpLiterals: true,
-				ignoreUrls: true,
-			},
-		],
-
 		// If a console.log is being used in code for good reason in production, it should be calling an api for warning or error reporting like Sentry or Dashbird
 		'no-console': 'warn',
 		'no-extra-parens': [


### PR DESCRIPTION
Whats your thoughts? Since VS Code has pretty good auto line wrap I'm not as huge into line lengths