### PR TITLE
removing empty ignoredNodes array

### DIFF
--- a/styles/fixable.js
+++ b/styles/fixable.js
@@ -37,7 +37,6 @@ module.exports = {
 					let: 2,
 					var: 2,
 				},
-				ignoredNodes: [],
 				outerIIFEBody: 1,
 			},
 		],


### PR DESCRIPTION
Before the change:
```sh
Referenced from: /Users/calebbrewer/dev/noc/node_modules/eslint-config-volta/styles/recommended.js
Referenced from: eslint-config-volta
Referenced from: /Users/calebbrewer/dev/noc/.eslintrc
Error: /Users/calebbrewer/dev/noc/node_modules/eslint-config-volta/styles/fixable.js:
        Configuration for rule "indent" is invalid:
        Value "data["1"].ignoredNodes" has additional properties.
```

After the change: 🌴 🍹 

Have you seen this issue too?