### PR TITLE
adding in jsx line prop rules

### DIFF
--- a/environment/react.js
+++ b/environment/react.js
@@ -32,6 +32,8 @@ module.exports = { // eslint-disable-line no-undef
     // Validate closing bracket location in JSX
     // This rule checks all JSX multiline elements and verifies the location of the closing bracket.
     'react/jsx-closing-bracket-location': ['warn', 'line-aligned'],
+    'react/jsx-first-prop-new-line': [1, 'multiline-multiprop'],
+    'react/jsx-max-props-per-line': [1, { "maximum": 1, "when": 'multiline' }],
     'react/jsx-no-undef': 'error',
     'react/jsx-uses-vars': 'warn',
     'react/no-array-index-key': 'warn',


### PR DESCRIPTION
[jsx-first-prop-new-line](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md)
- I'm undecided if I want this to be `multi-line` or `multiline-multiprop`

[jsx-max-props-per-line](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md)


