### PR TITLE
minor upadate to prop rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cp node_modules/eslint-config-volta/.editorconfig .
 ```
 
 # Publishing to NPM
-> Run this command from the master branch when there are new updates. 
+> Run this command from the branch you want to make changes to, and 
 
 ```
 yarn publish

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Open up the project you wish to prettify and these packages:
 ```
 yarn add --dev lint-staged husky eslint
-yarn add --dev https://github.com/Volta-Charging/eslint-config-volta.git
+yarn add --dev @volta/eslint-config-volta
 ```
 
 ## Step 2: extending eslint rules
@@ -43,5 +43,12 @@ mv node_modules/eslint-config-volta/.vscode/ .vscode/
 TODO: automate copying this file on the package install
 ```
 cp node_modules/eslint-config-volta/.editorconfig .
+```
+
+# Publishing to NPM
+> Run this command from the master branch when there are new updates. 
+
+```
+yarn publish
 ```
 

--- a/environment/react.js
+++ b/environment/react.js
@@ -33,7 +33,7 @@ module.exports = { // eslint-disable-line no-undef
     // This rule checks all JSX multiline elements and verifies the location of the closing bracket.
     'react/jsx-closing-bracket-location': ['warn', 'line-aligned'],
     'react/jsx-first-prop-new-line': [1, 'multiline-multiprop'],
-    'react/jsx-max-props-per-line': [1, { "maximum": 1, "when": 'multiline' }],
+    'react/jsx-max-props-per-line': [1, { "maximum": 1, "when": 'always' }],
     'react/jsx-no-undef': 'error',
     'react/jsx-uses-vars': 'warn',
     'react/no-array-index-key': 'warn',

--- a/environment/react.js
+++ b/environment/react.js
@@ -35,6 +35,7 @@ module.exports = { // eslint-disable-line no-undef
     'react/jsx-first-prop-new-line': [1, 'multiline-multiprop'],
     'react/jsx-max-props-per-line': [1, { "maximum": 1, "when": 'always' }],
     'react/jsx-no-undef': 'error',
+    'react/jsx-sort-props': 1,
     'react/jsx-uses-vars': 'warn',
     'react/no-array-index-key': 'warn',
     'react/no-danger': 'warn',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volta/eslint-config-volta",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Volta-Charging/lint-config.git"


### PR DESCRIPTION
- Minor fix to prop rules. We want to ensure there is always one prop per line. 

```js
<marker style ={styles} data={data} l3={data.l3] /> 
``` 
> This would not be updated by `es-lint` and would not throw any warnings.  