### PR TITLE
so typescript works again

### DIFF
--- a/environment/node/typescript.js
+++ b/environment/node/typescript.js
@@ -7,5 +7,12 @@ module.exports = { // eslint-disable-line no-undef
     ecmaVersion: 6,
     sourceType: 'module',
   },
-  settings: { 'import/resolver': { node: { extensions: [ '.ts' ] } } },
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: [ '.js',
+          '.ts' ],
+      },
+    },
+  },
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "devDependencies": {
     "husky": "^0.14.3",
-    "lint-staged": "^7.0.0"
+    "lint-staged": "^7.0.0",
+    "typescript": "^3.1.6"
   },
   "keywords": [
     "style guide",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "devDependencies": {
     "husky": "^0.14.3",
-    "lint-staged": "^7.0.0",
-    "typescript": "^3.1.6"
+    "lint-staged": "^7.0.0"
   },
   "keywords": [
     "style guide",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volta/eslint-config-volta",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/Volta-Charging/lint-config.git"

--- a/src/fixable.js
+++ b/src/fixable.js
@@ -19,7 +19,7 @@ module.exports = {
     'eol-last': [ 'warn', 'always' ],
     'function-paren-newline': [ 'warn', { minItems: 3 }],
     'import/no-useless-path-segments': 'warn',
-    'import/order': [ 'warn', { 'newlines-between': 'always' }],
+    'import/order': [ 'error', { 'newlines-between': 'always-and-inside-groups' }],
     // Arguably the most hotly debated rule
     indent: [
       'warn',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3043,11 +3043,6 @@ typescript-estree@2.1.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
-
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3043,6 +3043,11 @@ typescript-estree@2.1.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
+typescript@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"


### PR DESCRIPTION
1. we need to extend `.js` and `.ts` for node modules without type definitions.
1. import/order got changed to be more lenient because eslint things were breaking
1. `typescript` was added as a `devDependancy` so package builds dont complain