### PR TITLE
Stefan/react native updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,7 @@
   "eslint.enable": true,
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
 }

--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ Warn when you have a dangling comma on a non-multiline entity. Avoid syntax befo
 
 This rule errors when there are inconsistent newlines around function parentheses. Consistency wins readability.
 
-`'max-params': [ 'warn', { max: 4 }],`
-
-Warn when function argument list count reaches 4. Keep contracts down in complexity  and for flexibility use named/typed object contracts.
-
 # Testing New Linting Rules
 
 How do I know that the new eslint-config-volta will work good? Glad you asked partner! With our handy dandy `yarn link` testing's a doozy. Let me show yall:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add precommit hooks to `package.json`:
 {
   "scripts": {
     "precommit": "lint-staged",
-    "lint": "eslint --fix src"
+    "lint": "eslint '*/**/*.{js,ts,tsx}' --fix --quiet"
   },
   "lint-staged": {
     "*.js": [

--- a/environment/react-native.js
+++ b/environment/react-native.js
@@ -4,5 +4,10 @@ module.exports = { // eslint-disable-line no-undef
   env: { 'react-native/react-native': true },
   extends: [ './react.js', 'plugin:react-native/all' ],
   plugins: [ 'react-native' ],
-  rules: { 'react-native/no-inline-styles': 'off' },
+  rules: {
+    'react-native/no-inline-styles': 'off',
+    'react-native/no-raw-text': 'off',
+    'react-native/sort-styles': 'warn',
+    'react-native/no-unused-styles': 'warn',
+  },
 }

--- a/index.js
+++ b/index.js
@@ -23,9 +23,13 @@ module.exports = { // eslint-disable-line no-undef
     'computed-property-spacing': [ 'warn', 'never' ],
     'consistent-this': [ 'warn', 'self' ],
     'eol-last': [ 'warn', 'always' ],
-    'function-paren-newline': [ 'error', 'consistent' ],
+    'function-paren-newline': ['error', { 'minItems': 4 }],
+    'generator-star-spacing': ['error', { 'before': false, 'after': true }],
     'import/no-useless-path-segments': 'warn',
-    'import/order': [ 'error', { 'newlines-between': 'always-and-inside-groups' }],
+    'import/order': ['warn', {
+      'newlines-between': 'always',
+      'groups': [['builtin', 'internal', 'external'], 'parent', 'sibling', 'index'],
+    }],
     indent: [ 'warn', 2, { SwitchCase: 1 }],
     'keyword-spacing': [
       'warn', { after: true,
@@ -34,7 +38,7 @@ module.exports = { // eslint-disable-line no-undef
     'linebreak-style': [ 'error', 'unix' ],
     'lines-between-class-members': [ 'warn', 'always', { exceptAfterSingleLine: true }],
     'max-nested-callbacks': [ 'warn', 3 ],
-    'max-params': [ 'warn', { max: 4 }],
+    'max-params': 'off',
     'newline-per-chained-call': [ 'error', { ignoreChainWithDepth: 2 }],
     'no-console': 'warn', // If a console.log is being used in code for good reason in production, it should be calling an api for warning or error reporting like Sentry or Dashbird
     'no-extra-parens': [
@@ -49,9 +53,16 @@ module.exports = { // eslint-disable-line no-undef
     ],
     'no-trailing-spaces': 'warn',
     'no-undef': 'warn',
-    'object-curly-newline': [ 'warn', { consistent: true }],
+    'object-curly-newline': [
+      'warn', {
+        'ObjectExpression': { 'multiline': true, 'minProperties': 3 },
+        'ObjectPattern': { 'multiline': true, 'minProperties': 3 },
+        'ImportDeclaration': { 'multiline': true },
+        'ExportDeclaration': { 'multiline': true, 'minProperties': 3 }
+      },
+    ],
     'object-curly-spacing': [ 'warn', 'always' ],
-    'object-property-newline': 'warn',
+    'object-property-newline': ['warn', { 'allowAllPropertiesOnSameLine': true }],
     'one-var-declaration-per-line': 'warn',
     'prefer-const': 'warn',
     'prefer-numeric-literals': 'warn',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volta/eslint-config-volta",
-  "version": "0.2.4",
+  "version": "0.2.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Volta-Charging/eslint-config-volta.git"


### PR DESCRIPTION
# For the author
- [x] Tested locally
- [x] Version is bumped [semantically](https://semver.org/)

# For reviewers
## Where to focus
* Install the latest published `eslint-config-volta` (version 0.2.6) in whichever node service you like and see what you think of the new rules!
* All of these rules are being used now in the mobile application. This PR's goal is to simply upstream change our desired eslint rules.
* If you hate a rule - feel free to comment saying let's move this back to the olden days and I'll happily revert whichever line.